### PR TITLE
switching baseurl to /pymarlin/

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,7 +3,7 @@ module.exports = {
   title: 'PyMarlin',
   tagline: 'Lightweight PyTorch Training Framework',
   url: 'https://github.com/microsoft/PyMarlin',
-  baseUrl: '/',
+  baseUrl: '/PyMarlin/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
needed now that repo is public and we are using the path microsoft.github.io/pymarlin