### PR TITLE
Parametrize marlin example in Azure ML submission script

### DIFF
--- a/examples/azureml/azureml_submit.py
+++ b/examples/azureml/azureml_submit.py
@@ -6,54 +6,63 @@ from azureml.core.runconfig import PyTorchConfiguration, MpiConfiguration
 from azureml.data import OutputFileDatasetConfig
 from azureml.exceptions import ComputeTargetException
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--target_name", default="sriovdedicated1")
-parser.add_argument("--node_count", "-n", type=int, default=1)
-parser.add_argument("--process_count", "-p", type=int, default=1)
-parser.add_argument("--experiment_name", type=str, default="marlin-tests")
-parser.add_argument("--distributed_config", "-d", type=str, choices=["mpi", "pytorch"], default="pytorch")
-parser.add_argument("--backend", "-b", choices=["sp", "ddp-amp"], default="sp")
-parser.add_argument("--wait", "-w", action="store_true", help="Throw error is Azure ML job fails.")
-args = parser.parse_args()
+def classification_example():
+    """Prepare the environment and submission command for the classification example."""
+    env = Environment("pymarlin_requirements")
+    env.docker.enabled = True
+    env.docker.base_image = None
+    env.docker.base_dockerfile = 'examples/azureml/dockerfile'
+    env.python.user_managed_dependencies = True
+    env.python.interpreter_path = "/opt/miniconda/bin/python"
+    env.register(ws)
 
-ws = Workspace.from_config("examples/azureml/config.json")
+    cmd = f"pip install -U -e . && cd examples/classification/pymarlin_scripts && python train.py --trainer.backend {args.backend}".split()
+    
+    return env, cmd
+    
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--marlin_example", type=str, choices=["classification"], default="classification")
+    parser.add_argument("--target_name", default="sriovdedicated1")
+    parser.add_argument("--node_count", "-n", type=int, default=1)
+    parser.add_argument("--process_count", "-p", type=int, default=1)
+    parser.add_argument("--experiment_name", type=str, default="marlin-tests")
+    parser.add_argument("--distributed_config", "-d", type=str, choices=["mpi", "pytorch"], default="pytorch")
+    parser.add_argument("--backend", "-b", choices=["sp", "ddp-amp"], default="sp")
+    parser.add_argument("--wait", "-w", action="store_true", help="Throw error is Azure ML job fails.")
+    args = parser.parse_args()
 
-target = ws.compute_targets[args.target_name]
+    ws = Workspace.from_config("examples/azureml/config.json")
 
-if args.distributed_config == "pytorch":
-    distributed_job_config = PyTorchConfiguration(
-        process_count=args.process_count, node_count=args.node_count
+    target = ws.compute_targets[args.target_name]
+
+    if args.distributed_config == "pytorch":
+        distributed_job_config = PyTorchConfiguration(
+            process_count=args.process_count, node_count=args.node_count
+        )
+    elif args.distributed_config == "mpi":
+        distributed_job_config = MpiConfiguration(
+            process_count_per_node=args.process_count, node_count=args.node_count
+        )
+    else:
+        raise ValueError(f"Didn't recognize the distributed config {args.distributed_config}. Select on of 'mpi' or 'pytorch'.")
+
+    if args.marlin_example == "classification":
+        env, cmd = classification_example()
+
+    src = ScriptRunConfig(
+        source_directory='.',
+        command=cmd,
+        compute_target=target,
+        distributed_job_config=distributed_job_config,
+        environment=env,
     )
-elif args.distributed_config == "mpi":
-    distributed_job_config = MpiConfiguration(
-        process_count_per_node=args.process_count, node_count=args.node_count
-    )
-else:
-    raise ValueError(f"Didn't recognize the distributed config {args.distributed_config}. Select on of 'mpi' or 'pytorch'.")
 
-env = Environment("pymarlin_requirements")
-env.docker.enabled = True
-env.docker.base_image = None
-env.docker.base_dockerfile = 'examples/azureml/dockerfile'
-env.python.user_managed_dependencies = True
-env.python.interpreter_path = "/opt/miniconda/bin/python"
-env.register(ws)
+    print("Submitting experiment...")
+    run = Experiment(ws, args.experiment_name).submit(src)
 
-cmd = f"pip install -U -e . && cd examples/classification/pymarlin_scripts && python train.py --trainer.backend {args.backend}".split()
+    print(f"{run.get_portal_url()}")
 
-src = ScriptRunConfig(
-    source_directory='.',
-    command=cmd,
-    compute_target=target,
-    distributed_job_config=distributed_job_config,
-    environment=env,
-)
-
-print("Submitting experiment...")
-run = Experiment(ws, args.experiment_name).submit(src)
-
-print(f"{run.get_portal_url()}")
-
-if args.wait:
-    print("Waiting for run completion...")
-    run.wait_for_completion(show_output=True, raise_on_error=True)
+    if args.wait:
+        print("Waiting for run completion...")
+        run.wait_for_completion(show_output=True, raise_on_error=True)

--- a/website/docs/examples/azureml.md
+++ b/website/docs/examples/azureml.md
@@ -1,0 +1,17 @@
+---
+title: Azure ML
+---
+
+You can use [`examples/azureml/azureml_submit.py`](https://github.com/microsoft/PyMarlin/blob/main/examples/azureml/azureml_submit.py)
+to submit examples to run on Azure ML.
+
+For example:
+
+```bash
+python examples/azureml/azureml_submit.py --marlin_example classification --backend ddp-amp --process_count 2
+```
+
+See `examples/azureml/azureml_submit.py -h` for more options.
+
+**Note.** please modify the ['examples/azureml/config.json'](https://github.com/microsoft/PyMarlin/blob/main/examples/azureml/config.json)
+to reference your desired Azure ML workspace. See [Azure ML CheatSheet](https://aka.ms/aml/cheatsheet) for more details.


### PR DESCRIPTION
Adds argument `marlin_example` that controls the environment and submission command used to submit the run to azureml.

Only supports the classification task, other tasks can be added to this submission script later.