### PR TITLE
ORT Module Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ ENV/
 env.bak/
 venv.bak/
 *_env.py
+*_envs
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+*_env.py
 
 # Spyder project settings
 .spyderproject

--- a/examples/cnndailymail_text_summarization/config-ort.yaml
+++ b/examples/cnndailymail_text_summarization/config-ort.yaml
@@ -1,0 +1,43 @@
+data_path: 'D:/data/cnn_cln'
+dist: true
+ortds: false
+ort: false
+
+trainer:
+    max_train_steps_per_epoch : 100 # Maximum train steps per epoch.
+    max_val_steps_per_epoch : 100 # Maximum validation steps per epoch.
+    train_batch_size: 32 # Training global batch size.
+    val_batch_size: 32 # Validation batch size per GPU.
+    epochs: 3 # Total epochs to run.
+    ort: True
+    gpu_batch_size_limit : 4 # Max limit for GPU batch size during training.
+    disable_tqdm : True
+    writers: ["stdout", "aml", "tensorboard"]
+    backend: 'ddp-amp'
+
+module:
+    max_length_encoder : 1024
+    max_length_decoder : 128
+
+wrt:
+    tb_log_dir : 'outputs/tb_logs'
+
+
+stat:
+    log_steps : 20
+
+chkp:
+    checkpoint : True
+    delete_existing_checkpoints: False
+    save_dir: 'outputs/chkpt' # aml output path. does not require mounting
+    model_state_save_dir: 'outputs/model'
+    load_dir: null
+    load_filename: null
+
+# add more from BartForConditionalGeneration.generate?
+generate:
+    max_length: 128
+    do_sample : False
+    num_beams : 5
+# support everything in a yaml. ignore (print warning) everything that's not present.
+# Do not add the requirement to define anything in the parser other than yamls

--- a/examples/cnndailymail_text_summarization/config-ortds.yaml
+++ b/examples/cnndailymail_text_summarization/config-ortds.yaml
@@ -9,6 +9,7 @@ trainer:
     train_batch_size: 32 # Training global batch size.
     val_batch_size: 32 # Validation batch size per GPU.
     epochs: 3 # Total epochs to run.
+    ort: True
     gpu_batch_size_limit : 4 # Max limit for GPU batch size during training.
     disable_tqdm : True
     writers: ["stdout", "aml", "tensorboard"]

--- a/examples/cnndailymail_text_summarization/deepspeed_methods/deepspeed_utils.py
+++ b/examples/cnndailymail_text_summarization/deepspeed_methods/deepspeed_utils.py
@@ -46,6 +46,6 @@ def get_core_model(model, deepspeed_flag=False, ort_flag=False):
     if deepspeed_flag:
         module = module.module
     if ort_flag:
-        module = module._original_module
+        module = module._module_metadata.original_module
 
     return module

--- a/pymarlin/core/trainer.py
+++ b/pymarlin/core/trainer.py
@@ -144,7 +144,6 @@ class Trainer(AbstractTrainer):
         self.trainer_backend.update_state(self.checkpointed_states.trainer_backend_state)
 
         if self.args.ort: 
-            print("[--- ENTERING CHANGES ---]")
             from torch_ort import ORTModule 
 
             assert(hasattr(self, 'model') and isinstance(self.model, torch.nn.module), "expected self.model property of type torch.nn.module")


### PR DESCRIPTION
ORT Module has been integrated into the trainer script successfully.

- Created a new config file (**config-ort.yaml**) that just includes ORT references without DeepSpeed.
- Modified _trainer.py_ so that ORT can be enabled/disabled whenever the _trainer: ort_ field is set to True/False.  
- Implemented throughput logging into the _trainer.py_.
- Updated _.gitignore_ to include 2 more formats for local environment variable files/scripts. This was done for ease of use on my part. 