### PR TITLE
Have covid-19-text-classification run on both Linux and Windows

### DIFF
--- a/examples/covid19_text_classification/config.yaml
+++ b/examples/covid19_text_classification/config.yaml
@@ -49,9 +49,9 @@ module:
     log_level: 'INFO'
 
 data:
-    filepath_train: 'data\covid-19-nlp-text-classification\Corona_NLP_train.csv'
-    filepath_test: 'data\covid-19-nlp-text-classification\Corona_NLP_test.csv'
-    preprocessed_dir: 'data\covid-19-nlp-text-classification\preprocessed\bert'
+    filepath_train: 'data/covid-19-nlp-text-classification/Corona_NLP_train.csv'
+    filepath_test: 'data/covid-19-nlp-text-classification/Corona_NLP_test.csv'
+    preprocessed_dir: 'data/covid-19-nlp-text-classification/preprocessed/bert'
     encoding: 'ISO-8859-1'
     text_field: 'OriginalTweet'
     label_field: 'Sentiment'

--- a/examples/covid19_text_classification/data.py
+++ b/examples/covid19_text_classification/data.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from dataclasses import dataclass
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -11,9 +12,9 @@ from pymarlin import CustomArgParser
 
 @dataclass
 class DataInterfaceArguments:
-    filepath_train: str = 'data\covid-19-nlp-text-classification\Corona_NLP_train.csv'
-    filepath_test: str = 'data\covid-19-nlp-text-classification\Corona_NLP_test.csv'
-    preprocessed_dir: str = 'data\covid-19-nlp-text-classification\preprocessed'
+    filepath_train: str = 'data/covid-19-nlp-text-classification/Corona_NLP_train.csv'
+    filepath_test: str = 'data/covid-19-nlp-text-classification/Corona_NLP_test.csv'
+    preprocessed_dir: str = 'data/covid-19-nlp-text-classification/preprocessed'
     encoding: str = 'ISO-8859-1'
     text_field: str = 'OriginalTweet'
     label_field: str = 'Sentiment'
@@ -54,7 +55,7 @@ class Stage1(DataProcessor):
         self.logger.info('Stage 1 preprocessing successful')
 
     def _read_and_save(self, filepath):
-        df = pd.read_csv(filepath,
+        df = pd.read_csv(Path(filepath),
                          encoding=self.args.encoding)
 
         #Remove unnecessary columns (dummy preprocessing)
@@ -63,9 +64,9 @@ class Stage1(DataProcessor):
         self.logger.debug(df.head())
 
         # Save
-        filename = filepath.split('\\')[-1].split('.')[0]
-        os.makedirs(self.args.preprocessed_dir, exist_ok=True)
-        df.to_csv(os.path.join(self.args.preprocessed_dir, filename+'_stage1.csv'))
+        filename = Path(filepath).stem
+        os.makedirs(Path(self.args.preprocessed_dir), exist_ok=True)
+        df.to_csv(os.path.join(Path(self.args.preprocessed_dir), filename+'_stage1.csv'))
 
 
 class Stage2(DataProcessor):
@@ -82,12 +83,12 @@ class Stage2(DataProcessor):
 
     # This function doesnt need any inputs other than those from DataInterfaceArguments
     def process(self):
-        train_filename = self.args.filepath_train.split('\\')[-1].split('.')[0]
-        test_filename = self.args.filepath_test.split('\\')[-1].split('.')[0]
-        self.train = pd.read_csv(os.path.join(self.args.preprocessed_dir,
+        train_filename = Path(self.args.filepath_train).stem
+        test_filename = Path(self.args.filepath_test).stem
+        self.train = pd.read_csv(os.path.join(Path(self.args.preprocessed_dir),
                                               train_filename+'_stage1.csv'),
                                  encoding=self.args.encoding)
-        test = pd.read_csv(os.path.join(self.args.preprocessed_dir,
+        test = pd.read_csv(os.path.join(Path(self.args.preprocessed_dir),
                                         test_filename+'_stage1.csv'),
                            encoding=self.args.encoding)
 
@@ -117,12 +118,12 @@ class Stage2(DataProcessor):
         self.logger.info(self.train.head())
 
         plt.style.use('ggplot')
-        _ = plt.hist([len(t.split(' ')) for t in self.train[self.args.text_field]])
+        _ = plt.hist([len(str(t).split(' ')) for t in self.train[self.args.text_field]])
         plt.title('words in tweet')
         plt.show(block = False)
 
         plt.figure()
-        _ = plt.hist(self.train[self.args.label_field])
+        _ = plt.hist(self.train[self.args.label_field].astype(str))
         plt.title('Sentiments')
         plt.show(block = False)
 

--- a/examples/covid19_text_classification/readme.md
+++ b/examples/covid19_text_classification/readme.md
@@ -5,21 +5,41 @@
         pip install -r requirements.txt
 2. Download data from kaggle
         Ref: https://github.com/Kaggle/kaggle-api
-        Get your credentials file from kaggle here: C:\Users\<user>\.kaggle\kaggle.json
-        mkdir data
-        cd data
-        kaggle datasets download -d datatattle/covid-19-nlp-text-classification
-        (if windows): Expand-Archive .\covid-19-nlp-text-classification.zip 
-        (else): unzip ./covid-19-nlp-text-classification.zip 
+        
+	Get your credentials file from kaggle here: C:\Users\<user>\.kaggle\kaggle.json
+        
+	mkdir data
+        
+	cd data
+        
+	kaggle datasets download -d datatattle/covid-19-nlp-text-classification
+        
+	(if windows): Expand-Archive .\covid-19-nlp-text-classification.zip 
+        
+	(else): unzip ./covid-19-nlp-text-classification.zip 
+		
+		mkdir covid-19-nlp-text-classification
+		
+		move the two csv files to the new folder
+
 3. Install pymarlin library
+
         pip install pymarlin
+
         or
+
         $env:PYTHONPATH=<pymarlin repo path>
+
 4. Set working directory
+
         cd ..
+
 5. Prepare data
+
         python data.py
+
 6. Train
+
         python train.py [--trainer.max_train_steps_per_epoch 2]
 
 ## Running AzureML

--- a/pymarlin/core/trainer_backend.py
+++ b/pymarlin/core/trainer_backend.py
@@ -106,11 +106,13 @@ class TrainerBackend(ABC):
     def get_global_steps_completed(self):
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def train_sampler(self):
         return RandomSampler
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def val_sampler(self):
         return SequentialSampler
 

--- a/pymarlin/core/trainer_backend.py
+++ b/pymarlin/core/trainer_backend.py
@@ -13,7 +13,7 @@ These are `TrainerBackends` for most common scenarios available out of the box.
 Alternatively a user can provide a custom `TrainerBackend`.
 """
 from tqdm.auto import tqdm
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 import dataclasses
 from typing import Iterable, Optional, Union
 import warnings


### PR DESCRIPTION
What's new:

- updated readme.md with improved formatting and additional instructions for Linux
- updated config.yaml to work with pathlib
- updated data.py to allow the example to run on both Linux and Windows terminal