### PR TITLE
incremented the pytorch dependency version to <=1.9.1

### DIFF
--- a/VERSION_NOTES.md
+++ b/VERSION_NOTES.md
@@ -1,4 +1,7 @@
 # Version Notes:
+## 0.2.8
+* Incremented the dependency to torch<=1.9.1
+
 ## 0.2.7
 * Adding torch<=1.9 as required dependency
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-required = ['torch<=1.9','tqdm','tensorboard', 'Pillow','azureml-core','pyyaml','pandas']
+required = ['torch<=1.9.1','tqdm','tensorboard', 'Pillow','azureml-core','pyyaml','pandas']
 extras = {
     'dev': ['pylint', 'pytest', 'pytest-cov'],
     'plugins': ['transformers','pandas','matplotlib','sklearn','scipy','rouge-score']
@@ -11,7 +11,7 @@ extras = {
 
 setup(
     name="pymarlin",
-    version="0.2.7",
+    version="0.2.8",
     author="ELR Team",
     author_email="elrcore@microsoft.com",
     description="Lightweight Deeplearning Library",


### PR DESCRIPTION
PyMarlin currently throws some CUDA exceptions in certain scenarios on the Nvidia Pascal architecture with CUDA 11+ with PyTorch<=1.9. Incrementing the PyTorch version to 1.9.1 resolves these errors.