### PR TITLE
Modified nccl backend setup for compliant detonation chamber

### DIFF
--- a/pymarlin/utils/distributed.py
+++ b/pymarlin/utils/distributed.py
@@ -92,24 +92,13 @@ def set_environment_variables_for_nccl_backend():
     os.environ["NCCL_SOCKET_IFNAME"] = "^docker0,lo"
     os.environ["NCCL_IB_DISABLE"] = "0"  # for IB
 
-    single_node = int(os.environ["OMPI_COMM_WORLD_LOCAL_SIZE"]) == int(
-        os.environ["OMPI_COMM_WORLD_SIZE"]
-    )
-
-    if single_node:
-        master_node = os.environ["AZ_BATCHAI_MPI_MASTER_NODE"]
-        master_port = "54965"
-    else:
-        master_node_params = os.environ["AZ_BATCH_MASTER_NODE"].split(":")
-
-        master_node = master_node_params[0]
-        master_port = (
-            os.environ["MASTER_PORT"] if "MASTER_PORT" in os.environ else "6105"
-        )
+    master_node = os.environ["AZ_BATCHAI_MPI_MASTER_NODE"]
+    master_port = "54965"
 
     # set env variables
     os.environ["MASTER_ADDR"] = master_node
     os.environ["MASTER_PORT"] = master_port
+
 
 def rank_zero_only(fn):
     """Decorates functions to only execute on global rank 0, else wait via torch.distributed"""


### PR DESCRIPTION
This change causes master address to always be taken from `AZ_BATCHAI_MPI_MASTER_NODE`. This is done to enable distributed training in **compliant detonation chamber** across multiple nodes. According to [this stackoverflow post](https://stackoverflow.microsoft.com/questions/307822), `AZ_BATCHAI_MPI_MASTER_NODE` should always be used over `AZ_BATCH_MASTER_NODE` for both signed builds and in detonation chamber.